### PR TITLE
Fix dispatch for GeneXus integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,6 @@ jobs:
         PackageVersionString: ./.github/generatePackageVersion.ps1
       run: |
         $NuGetPackageVersion = & "$Env:PackageVersionString"
-        
         Write-Output "Package version to be used: $NuGetPackageVersion"
         echo "NuGetPackageVersion=$NuGetPackageVersion" >> $env:GITHUB_ENV
 


### PR DESCRIPTION
Project was moved from root to src directory when 'beta' branch was created; csproj was not been found for "Prepare build result" step.