### PR TITLE
AWS ElasticBeanstalk set ApplicationServer to Tomcat8.x

### DIFF
--- a/src/AWSElasticBeanstalk/Definition.target
+++ b/src/AWSElasticBeanstalk/Definition.target
@@ -7,7 +7,7 @@
 	<DeployMsbuildTarget>Deploy</DeployMsbuildTarget>
 	<PackageTargets>aws.targets</PackageTargets>
 	<Languages>
-		<Language Id="12" ApplicationServer="Generic Servlet 3.1"/>
+		<Language Id="12" ApplicationServer="Tomcat 8.x"/>
 		<Language Id="15" ApplicationServer="IIS8"/>
 	</Languages>
 	<DataSources>


### PR DESCRIPTION
ApplicationServer value was incorrect.

EB requires Tomcat 8.x. 

https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.java
