### PR TITLE
Increase version for the next upgrade

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<MajorFileVersion>1</MajorFileVersion>
 		<MajorFileVersion Condition="$(GIT_REF.EndsWith('beta'))">$([MSBuild]::Add($(MajorFileVersion), 100))</MajorFileVersion>
-		<MinorFileVersion>9</MinorFileVersion>
+		<MinorFileVersion>10</MinorFileVersion>
 		<VersionSuffix Condition="'$(VersionSuffix)'=='' and $(UseDefaultSuffix)!='false'">-dev</VersionSuffix>
 		<RevisionFileVersion Condition="!$(GIT_REF.EndsWith('beta')) and !$(GIT_REF.EndsWith('master')) and '$(COMMIT_NUMBER)'!=''">$(COMMIT_NUMBER)</RevisionFileVersion>
 		<RevisionFileVersion Condition="'$(RevisionFileVersion)'==''">0</RevisionFileVersion>


### PR DESCRIPTION
- Preserve version 1.9 for hotfixes on GeneXus 18u1.