### PR TITLE
Single message processing of Service bus Azure functions and changes to Blob functions

### DIFF
--- a/src/AzureFunctions/Templates/NET/blob.st
+++ b/src/AzureFunctions/Templates/NET/blob.st
@@ -15,7 +15,7 @@ namespace BlobTriggerFunctions
         \}
 
         [Function("$class.functionName$")]
-        public void Run([BlobTrigger("$class.blobPath$", Connection = "$class.connectionName$")] Stream blobItem, FunctionContext context)
+        public void Run([BlobTrigger("$class.blobPath$", Source = BlobTriggerSource.EventGrid, Connection = "$class.connectionName$")] Stream blobItem, FunctionContext context)
         {
             BlobTriggerHandler function = new BlobTriggerHandler(_callmappings);
             function.Run(blobItem, context);

--- a/src/AzureFunctions/Templates/NET/servicebusqueuesinglemessage.st
+++ b/src/AzureFunctions/Templates/NET/servicebusqueuesinglemessage.st
@@ -4,7 +4,7 @@ using GeneXus.Deploy.AzureFunctions.Handlers.Helpers;
 using GeneXus.Deploy.AzureFunctions.ServiceBusHandler;
 using Microsoft.Azure.Functions.Worker;
 
-namespace ServiceBusQueueFunctions
+namespace ServiceBusQueueSingleProcessingFunctions
 {
     $classes:{class | 
     public class $class.className$

--- a/src/AzureFunctions/Templates/NET/servicebusqueuesinglemessage.st
+++ b/src/AzureFunctions/Templates/NET/servicebusqueuesinglemessage.st
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using GeneXus.Deploy.AzureFunctions.Handlers.Helpers;
+using GeneXus.Deploy.AzureFunctions.ServiceBusHandler;
+using Microsoft.Azure.Functions.Worker;
+
+namespace ServiceBusQueueFunctions
+{
+    $classes:{class | 
+    public class $class.className$
+    {
+        private ICallMappings _callmappings;
+		public $class.className$(ICallMappings callMappings)
+        {
+            _callmappings = callMappings;
+        \}
+
+        [Function("$class.functionName$")]
+        public async Task RunSingle([ServiceBusTrigger("$class.queueName$", Connection = "$class.connectionName$", IsBatched = false, IsSessionsEnabled=$class.sessionEnabled$)] ServiceBusReceivedMessage receivedMessages, FunctionContext context)
+        {
+            ServiceBusTriggerHandler function = new ServiceBusTriggerHandler(_callmappings);
+            await function.RunSingle(receivedMessages, context);
+        \}
+       
+    \}
+    }$
+}

--- a/src/AzureFunctions/Templates/NET/servicebustopic.st
+++ b/src/AzureFunctions/Templates/NET/servicebustopic.st
@@ -4,7 +4,7 @@ using GeneXus.Deploy.AzureFunctions.Handlers.Helpers;
 using GeneXus.Deploy.AzureFunctions.ServiceBusHandler;
 using Microsoft.Azure.Functions.Worker;
 
-namespace ServiceBusQueueFunctions
+namespace ServiceBusTopicFunctions
 {
     $classes:{class | 
     public class $class.className$

--- a/src/AzureFunctions/Templates/NET/servicebustopicsinglemessage.st
+++ b/src/AzureFunctions/Templates/NET/servicebustopicsinglemessage.st
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using GeneXus.Deploy.AzureFunctions.Handlers.Helpers;
+using GeneXus.Deploy.AzureFunctions.ServiceBusHandler;
+using Microsoft.Azure.Functions.Worker;
+
+namespace ServiceBusQueueFunctions
+{
+    $classes:{class | 
+    public class $class.className$
+    {
+        private ICallMappings _callmappings;
+
+        public $class.className$(ICallMappings callMappings)
+        {
+            _callmappings = callMappings;
+        \}
+
+        [Function("$class.functionName$")]
+        public async Task RunSingle([ServiceBusTrigger("$class.topicName$","$class.subscriptionName$", Connection = "$class.connectionName$", IsBatched = false, IsSessionsEnabled=$class.sessionEnabled$)] ServiceBusReceivedMessage receivedMessages, FunctionContext context)
+        {
+            ServiceBusTriggerHandler function = new ServiceBusTriggerHandler(_callmappings);
+            await function.RunSingle(receivedMessages, context);
+        \}
+    \}
+    }$
+}

--- a/src/AzureFunctions/Templates/NET/servicebustopicsinglemessage.st
+++ b/src/AzureFunctions/Templates/NET/servicebustopicsinglemessage.st
@@ -4,7 +4,7 @@ using GeneXus.Deploy.AzureFunctions.Handlers.Helpers;
 using GeneXus.Deploy.AzureFunctions.ServiceBusHandler;
 using Microsoft.Azure.Functions.Worker;
 
-namespace ServiceBusQueueFunctions
+namespace ServiceBusTopicSingleProcessingFunctions
 {
     $classes:{class | 
     public class $class.className$

--- a/src/AzureFunctions/azurefunctions.targets
+++ b/src/AzureFunctions/azurefunctions.targets
@@ -98,6 +98,10 @@
 			Text="Azure functions deployment failed: The service bus connection cannot be empty"
 			Condition="'$(AZURE_FUNCTIONS_SERVICEBUS_CONNECTION)' == '' AND $(AZURE_FUNCTIONS_TRIGGER_TYPE) == 'servicebus'" />
 
+		<Error
+			Text="Azure functions deployment failed: The Blob Path and Connection Setting must be configured."
+			Condition="($(AZURE_FUNCTIONS_TRIGGER_TYPE) == 'blobstorage') AND ('$(AZURE_FUNCTIONS_BLOB_STORAGE_CONNECTION)' == '' OR '$(AZURE_FUNCTIONS_BLOB_STORAGE_PATH)' == '')" />
+
 	</Target>
 
 	<Target Name="ValidateRedisSupport" Condition="'$(AZURE_FUNCTIONS_TRIGGER_TYPE)' == 'http' AND '$(AZURE_FUNCTIONS_SESSION_STATE_PROVIDER)' == 'Redis'" >

--- a/src/AzureFunctions/deploy.msbuild
+++ b/src/AzureFunctions/deploy.msbuild
@@ -35,7 +35,8 @@
 	<Target Name="InitializeMappingVars" Inputs="@(SelectedObject)" Outputs="%(SelectedObject.Identity)" >
 		<PropertyGroup>
 			<EntryPointClassName Condition="'$(GENERATOR)' == 'Java'">$(Namespace).%(SelectedObject.QualifiedName)</EntryPointClassName>
-			<EntryPointClassName Condition = "'$(GENERATOR)' == '.NET Core' or '$(GENERATOR)' == '.NET'">%(SelectedObject.QualifiedName)</EntryPointClassName>
+			<EntryPointClassName Condition = "('$(GENERATOR)' == '.NET Core' or '$(GENERATOR)' == '.NET') AND '%(SelectedObject.Module)' != ''">%(SelectedObject.Module).a%(SelectedObject.Identity)</EntryPointClassName>
+			<EntryPointClassName Condition = "('$(GENERATOR)' == '.NET Core' or '$(GENERATOR)' == '.NET') AND '%(SelectedObject.Module)' == ''">a%(SelectedObject.Identity)</EntryPointClassName>
 			<EntryPointClassName>$(EntryPointClassName.ToLower())</EntryPointClassName>
 			<UpperFunctionName>$(AZURE_FUNCTIONS_FUNCTION_NAME.ToUpperInvariant())</UpperFunctionName>
 			<EnvVarName>GX_AZURE_$(UpperFunctionName)_CLASS</EnvVarName>
@@ -143,10 +144,6 @@
 		<Error
 			Text="Azure functions deployment failed: The APIM Version Set cannot be empty if the APIM API Version has a value."
 			Condition="$(AZURE_FUNCTIONS_TRIGGER_TYPE) == 'http' AND $(AZURE_APIM_API_VERSION_SET_ID) == '' AND $(AZURE_APIM_API_VERSION) != ''" />
-
-		<Error
-			Text="Azure functions deployment failed: The Blob Path and Connection Setting must be configured."
-			Condition="($(AZURE_FUNCTIONS_TRIGGER_TYPE) == 'blobstorage') AND ('$(AZURE_FUNCTIONS_BLOB_STORAGE_CONNECTION)' == '' OR '$(AZURE_FUNCTIONS_BLOB_STORAGE_PATH)' == '')" />
-
+			
 	</Target>
 </Project>

--- a/src/Common/Azure/azurefunctions-create-NETpackage.targets
+++ b/src/Common/Azure/azurefunctions-create-NETpackage.targets
@@ -59,6 +59,7 @@
 				<QueueName>$(AZURE_FUNCTIONS_SERVICEBUS_QUEUENAME)</QueueName>
 				<ConnectionName>$(AZURE_FUNCTIONS_SERVICEBUS_CONNECTION)</ConnectionName>
 				<IsSessionsEnabled>$(AZURE_FUNCTIONS_SERVICEBUS_ISSESSIONENABLED)</IsSessionsEnabled>
+				<IsBatch>$(AZURE_FUNCTIONS_SERVICEBUS_ISBATCH)</IsBatch>
 			</FunctionData>
 			<FunctionData Condition="'$(AZURE_FUNCTIONS_SERVICEBUS_TYPE)' == 'topic'" Include ="$(AZURE_FUNCTIONS_FUNCTION_NAME)">
 				<TriggerType>$(AZURE_FUNCTIONS_TRIGGER_TYPE)</TriggerType>
@@ -66,6 +67,7 @@
 				<SubscriptionName>$(AZURE_FUNCTIONS_SERVICEBUS_SUBSCRIPTIONNAME)</SubscriptionName>
 				<ConnectionName>$(AZURE_FUNCTIONS_SERVICEBUS_CONNECTION)</ConnectionName>
 				<IsSessionsEnabled>$(AZURE_FUNCTIONS_SERVICEBUS_ISSESSIONENABLED)</IsSessionsEnabled>
+				<IsBatch>$(AZURE_FUNCTIONS_SERVICEBUS_ISBATCH)</IsBatch>
 			</FunctionData>
 		</ItemGroup>
 

--- a/src/Common/Azure/azurefunctions-create-NETpackage.targets
+++ b/src/Common/Azure/azurefunctions-create-NETpackage.targets
@@ -63,7 +63,8 @@
 			</FunctionData>
 			<FunctionData Condition="'$(AZURE_FUNCTIONS_SERVICEBUS_TYPE)' == 'topic'" Include ="$(AZURE_FUNCTIONS_FUNCTION_NAME)">
 				<TriggerType>$(AZURE_FUNCTIONS_TRIGGER_TYPE)</TriggerType>
-				<QueueName>$(AZURE_FUNCTIONS_SERVICEBUS_TOPICNAME)</QueueName>
+				<ServiceBusType>$(AZURE_FUNCTIONS_SERVICEBUS_TYPE)</ServiceBusType>
+				<TopicName>$(AZURE_FUNCTIONS_SERVICEBUS_TOPICNAME)</TopicName>
 				<SubscriptionName>$(AZURE_FUNCTIONS_SERVICEBUS_SUBSCRIPTIONNAME)</SubscriptionName>
 				<ConnectionName>$(AZURE_FUNCTIONS_SERVICEBUS_CONNECTION)</ConnectionName>
 				<IsSessionsEnabled>$(AZURE_FUNCTIONS_SERVICEBUS_ISSESSIONENABLED)</IsSessionsEnabled>


### PR DESCRIPTION
Issue:202978
- Azure Functions triggered by Service Bus messages can manage batch messages or just a single message.
Depending on several factors, it may be advisable to process only one message (not batch).

- Breaking change in Azure functions triggered by Blob. Now we follow the recommendation of using event grid source. This means changes at infra for the user.