### PR TITLE
SAP deploy update to Jakarta platform support

### DIFF
--- a/src/SAPCloudFoundry/Definition.target
+++ b/src/SAPCloudFoundry/Definition.target
@@ -3,12 +3,20 @@
 	<Name>SAP BTP (Cloud Foundry)</Name>
 	<Version>1.0</Version>
 	<Description>DeployTo</Description>
-	<ApplicationServer>Tomcat 8.x</ApplicationServer>
 	<DeployMsbuild>deploy.msbuild</DeployMsbuild>
 	<DeployMsbuildTarget>Deploy</DeployMsbuildTarget>
 	<Languages>
 		<Language Id="12"/>
 	</Languages>
+	<Generators>	
+		<Generator>
+			<Id>12</Id>			
+			<Data>
+				<ApplicationServer>Tomcat 8.x</ApplicationServer>
+				<ApplicationServer>Tomcat 10.1</ApplicationServer>
+			</Data>
+		</Generator>		
+	</Generators>
 	<DataSources>
 		<DataSource Id="21" />
 	</DataSources>

--- a/src/SAPCloudFoundry/Templates/context.xml
+++ b/src/SAPCloudFoundry/Templates/context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Context>  <Resource name="jdbc/DefaultDB"
     auth="Container"
-    type="javax.sql.DataSource"
-    factory="com.sap.xs.jdbc.datasource.tomcat.TomcatDataSourceFactory"
+    type="$TYPE$"
+    factory="$FACTORY$"
     service="$SAPCF_HANAINSTANCENAME$"/>
 </Context>
 

--- a/src/SAPCloudFoundry/Templates/manifest.yml
+++ b/src/SAPCloudFoundry/Templates/manifest.yml
@@ -2,7 +2,7 @@ applications:
   - name: $SAPCF_APPNAME$
     path: ./$SAPCF_WAR$
     buildpacks:
-      - sap_java_buildpack
+      - $SAP_JAVA_BUILDPACK$
     memory: 1024M
     random-route: true
     env:

--- a/src/SAPCloudFoundry/Templates/manifest.yml
+++ b/src/SAPCloudFoundry/Templates/manifest.yml
@@ -6,6 +6,7 @@ applications:
     memory: 1024M
     random-route: true
     env:
+      JBP_CONFIG_TOMCAT: '{ tomcat: { $TOMCAT_VERSION$ } }'
       TARGET_RUNTIME: tomcat
       SET_LOGGING_LEVEL: '{ROOT: INFO, com.sap.cloud.sdk: INFO}'
       JBP_CONFIG_SAPJVM_MEMORY_SIZES: 'metaspace:128m..'

--- a/src/SAPCloudFoundry/deploy.msbuild
+++ b/src/SAPCloudFoundry/deploy.msbuild
@@ -39,13 +39,13 @@
 	<Target Name="GenerateManifestYML">
 		<GenerateFromTemplate Condition = "'$(ApplicationServer)' == 'Tomcat 8.x'"
 			TemplateFile="$(GX_PROGRAM_DIR)\DeploymentTargets\SAPCloudFoundry\Templates\manifest.yml"
-			Properties="SAPCF_APPNAME=$(SAPCF_APPNAME);SAPCF_WAR=$(APPLICATION_NAME).war;SAP_JAVA_BUILDPACK=sap_java_buildpack"
+			Properties="SAPCF_APPNAME=$(SAPCF_APPNAME);SAPCF_WAR=$(APPLICATION_NAME).war;SAP_JAVA_BUILDPACK=sap_java_buildpack;TOMCAT_VERSION=version: 8.5.+"
 			Items=""
 			ItemTypes=""
 			OutputFile="$(ManifestFile)" />
 		<GenerateFromTemplate Condition = "'$(ApplicationServer)' == 'Tomcat 10.1'"
 			TemplateFile="$(GX_PROGRAM_DIR)\DeploymentTargets\SAPCloudFoundry\Templates\manifest.yml"
-			Properties="SAPCF_APPNAME=$(SAPCF_APPNAME);SAPCF_WAR=$(APPLICATION_NAME).war;SAP_JAVA_BUILDPACK=sap_java_buildpack_jakarta"
+			Properties="SAPCF_APPNAME=$(SAPCF_APPNAME);SAPCF_WAR=$(APPLICATION_NAME).war;SAP_JAVA_BUILDPACK=sap_java_buildpack_jakarta;TOMCAT_VERSION=version: 10.1.+"
 			Items=""
 			ItemTypes=""
 			OutputFile="$(ManifestFile)" />

--- a/src/SAPCloudFoundry/deploy.msbuild
+++ b/src/SAPCloudFoundry/deploy.msbuild
@@ -39,7 +39,7 @@
 	<Target Name="GenerateManifestYML">
 		<GenerateFromTemplate Condition = "'$(ApplicationServer)' == 'Tomcat 8.x'"
 			TemplateFile="$(GX_PROGRAM_DIR)\DeploymentTargets\SAPCloudFoundry\Templates\manifest.yml"
-			Properties="SAPCF_APPNAME=$(SAPCF_APPNAME);SAPCF_WAR=$(APPLICATION_NAME).war;SAP_JAVA_BUILDPACK=sap_java_buildpack;TOMCAT_VERSION=version: 8.5.+"
+			Properties="SAPCF_APPNAME=$(SAPCF_APPNAME);SAPCF_WAR=$(APPLICATION_NAME).war;SAP_JAVA_BUILDPACK=sap_java_buildpack_to_be_removed;TOMCAT_VERSION=version: 8.5.+"
 			Items=""
 			ItemTypes=""
 			OutputFile="$(ManifestFile)" />

--- a/src/SAPCloudFoundry/deploy.msbuild
+++ b/src/SAPCloudFoundry/deploy.msbuild
@@ -11,6 +11,7 @@
 
 	<Target Name="Deploy" DependsOnTargets="GenerateContextXML;GenerateManifestYML">
 		<Message Text="Deploy to SAP BTP Cloud Foundry Environment" Importance="high"/>
+		<Message Text="SAP Java Buildpack 1 has been deprecated and is going to be removed from SAP BTP, Cloud Foundry environment as of December 2025. Use Tomcat 10.1 instead after building the application using Jakarta Java platform support." Condition="'$(ApplicationServer)' == 'Tomcat 8.x'" />
 		<Error Text="The Cloud Foundry CLI Directory cannot be empty" Condition="'$(SAPCF_CLI_DIR)' == ''"/>
 		<Error Text="The HANA Instance name cannot be empty" Condition="'$(SAPCF_HANAINSTANCENAME)' == ''"/>
 		<Error Text="The Application Name cannot be empty" Condition="'$(SAPCF_APPNAME)' == ''"/>
@@ -21,18 +22,30 @@
 	</Target>
 
 	<Target Name="GenerateContextXML">
-		<GenerateFromTemplate
+		<GenerateFromTemplate Condition = "'$(ApplicationServer)' == 'Tomcat 8.x'"
 			TemplateFile="$(GX_PROGRAM_DIR)\DeploymentTargets\SAPCloudFoundry\Templates\context.xml"
-			Properties="SAPCF_HANAINSTANCENAME=$(SAPCF_HANAINSTANCENAME)"
+			Properties="SAPCF_HANAINSTANCENAME=$(SAPCF_HANAINSTANCENAME);TYPE=javax.sql.DataSource;FACTORY=com.sap.xs.jdbc.datasource.tomcat.TomcatDataSourceFactory"
+			Items=""
+			ItemTypes=""
+			OutputFile="$(DeployFullPath)\META-INF\context.xml" />
+		<GenerateFromTemplate Condition = "'$(ApplicationServer)' == 'Tomcat 10.1'"
+			TemplateFile="$(GX_PROGRAM_DIR)\DeploymentTargets\SAPCloudFoundry\Templates\context.xml"
+			Properties="SAPCF_HANAINSTANCENAME=$(SAPCF_HANAINSTANCENAME);TYPE=javax.sql.DataSource;FACTORY=com.sap.xs.jdbc.datasource.jakarta.TomcatDataSourceFactory"
 			Items=""
 			ItemTypes=""
 			OutputFile="$(DeployFullPath)\META-INF\context.xml" />
 		<Exec Command='jar cf "$(SourceWar)" .' WorkingDirectory="$(DeployFullPath)" EchoOff="true" />
 	</Target>
 	<Target Name="GenerateManifestYML">
-		<GenerateFromTemplate
+		<GenerateFromTemplate Condition = "'$(ApplicationServer)' == 'Tomcat 8.x'"
 			TemplateFile="$(GX_PROGRAM_DIR)\DeploymentTargets\SAPCloudFoundry\Templates\manifest.yml"
-			Properties="SAPCF_APPNAME=$(SAPCF_APPNAME);SAPCF_WAR=$(APPLICATION_NAME).war"
+			Properties="SAPCF_APPNAME=$(SAPCF_APPNAME);SAPCF_WAR=$(APPLICATION_NAME).war;SAP_JAVA_BUILDPACK=sap_java_buildpack"
+			Items=""
+			ItemTypes=""
+			OutputFile="$(ManifestFile)" />
+		<GenerateFromTemplate Condition = "'$(ApplicationServer)' == 'Tomcat 10.1'"
+			TemplateFile="$(GX_PROGRAM_DIR)\DeploymentTargets\SAPCloudFoundry\Templates\manifest.yml"
+			Properties="SAPCF_APPNAME=$(SAPCF_APPNAME);SAPCF_WAR=$(APPLICATION_NAME).war;SAP_JAVA_BUILDPACK=sap_java_buildpack_jakarta"
 			Items=""
 			ItemTypes=""
 			OutputFile="$(ManifestFile)" />


### PR DESCRIPTION
Issue:206269


As of December 2025,
the Java Build Pack 1 we reference for deploying applications in SAP is no longer supported.
It now requires Java 17 or Java 21 and Jakarta.

We are introducing changes to support the new version.

https://help.sap.com/whats-new/cf0cb2cb149647329b5d02aa96303f56?Component=SAP+Java+Buildpack&Valid_as_Of=2025-10-01:2025-12-31&locale=en-US