### PR TITLE
Replace deprecated config-zip with functionapp deploy for .NET 10

### DIFF
--- a/src/AzureFunctions/deploy.msbuild
+++ b/src/AzureFunctions/deploy.msbuild
@@ -23,9 +23,9 @@
 	   		<pathToFile Include="$([MSBuild]::Escape('$(DeployFileFullPath)\$(ProjectName)_$(AZURE_FUNCTIONS_FUNCTION_NAME).zip'))" />
 	   </ItemGroup>
 
-	    <Message Text="Deploying to Azure functions ...." Importance="high"/>	
+	    <Message Text="Deploying to Azure functions ...." Importance="high"/>
 
-        <Exec Command="az functionapp deployment source config-zip -g $(AZURE_FUNCTIONS_RESOURCE_GROUP) -n $(AZURE_FUNCTIONS_FUNCTION_APP) --src %(pathToFile.Identity)" ConsoleToMSBuild="true" ContinueOnError="true" >
+		<Exec Command="az functionapp deploy --type zip -g $(AZURE_FUNCTIONS_RESOURCE_GROUP) -n $(AZURE_FUNCTIONS_FUNCTION_APP) --src-path %(pathToFile.Identity)" ConsoleToMSBuild="true" ContinueOnError="true" >
 			<Output TaskParameter="ConsoleOutput" PropertyName="OUTPUT_MESSAGE" />
 			<Output TaskParameter="ExitCode" PropertyName="AZ_EXIT_CODE"/>
 		</Exec>

--- a/src/AzureServerless/deploy.msbuild
+++ b/src/AzureServerless/deploy.msbuild
@@ -23,8 +23,9 @@
 	   		<pathToFile Include="$([MSBuild]::Escape('$(DeployFileFullPath)/$(ProjectName)_$(AZURE_SERVERLESS_FUNCTION_NAME).zip'))" />
 	   </ItemGroup>
 
-	    <Message Text="Deploying to Azure functions ...." Importance="high"/>	
-        <Exec Command="az functionapp deployment source config-zip -g $(AZURE_SERVERLESS_RESOURCE_GROUP) -n $(AZURE_SERVERLESS_FUNCTION_APP) --src %(pathToFile.Identity)" ConsoleToMSBuild="true" ContinueOnError="true" >
+	    <Message Text="Deploying to Azure functions ...." Importance="high"/>
+
+		<Exec Command="az functionapp deploy --type zip -g $(AZURE_SERVERLESS_RESOURCE_GROUP) -n $(AZURE_SERVERLESS_FUNCTION_APP) --src-path %(pathToFile.Identity)" ConsoleToMSBuild="true" ContinueOnError="true" >
 			<Output TaskParameter="ConsoleOutput" PropertyName="OUTPUT_MESSAGE" />
 			<Output TaskParameter="ExitCode" PropertyName="AZ_EXIT_CODE"/>
 		</Exec>


### PR DESCRIPTION
The command `az functionapp deployment source config-zip` returns `Bad Request` on Linux Function Apps running .NET 10 isolated. Replace it with the modern `az functionapp deploy --type zip`, which also supports Flex Consumption plans.
Issue:208451